### PR TITLE
Elide comments for live class

### DIFF
--- a/src/clojure_by_example/ex00_introduction.clj
+++ b/src/clojure_by_example/ex00_introduction.clj
@@ -1,43 +1,20 @@
 (ns clojure-by-example.ex00-introduction)
 
-
-;; IMPORTANT:
-;; - The README file explains why this project exists.
-;; - Begin in this "ex00..." file, and work through it step by step.
-;; - Once you are done with "ex00...", open the next file and repeat.
-;; - Keep going this way, until you have worked through all the files.
-
-
-;; EX00: LESSON GOAL:
-;; - A very quick intro to Clojure syntax, just to familiarize your
-;;   eyes with it.
-;;
-;; - Don't get stuck here!
-;;   - Run through it once, and move on to EX01.
-;;   - Your eyes and brain will adjust fairly quickly, as you
-;;     work through the examples to follow.
-
-
-
 ;; Clojure is a "Lisp"
-;; - Lisp is short for List Processing
-;; - It's just another way to design a programming language
-;;   (Ignore "But, Why?" for now... Just use it as it is, and try to
-;;    do something practical with it.)
+;; - Clojure code is composed of "expressions"
 
 
+;; These "literal" values are Clojure "expressions"
 
-;; Clojure code is composed of "expressions":
-
-;; These literal values are Clojure "expressions"
 "hello"                                 ; strings
 :hello                                  ; keywords
 'hello                                  ; symbols
 42                                      ; numbers
 22/7                                    ; fractional numbers
 
+
 ;; "Built-in" functions are also "expressions"
-;; - We will meet all of these again, very soon.
+
 +                                       ; addition
 map                                     ; map over a collection
 filter                                  ; filter from a collection
@@ -45,7 +22,7 @@ reduce                                  ; transform a collection
 
 
 ;; Collection "literals" are expressions too:
-;; - We will extensively use such "collection" data structures.
+
 [1 2 3 4 5]                             ; a vector
 {:a 1 :b 2}                             ; a hash-map
 #{1 2 3 4 5}                            ; a hash-set
@@ -54,47 +31,25 @@ reduce                                  ; transform a collection
 
 ;; Any Clojure code that evaluates to a value is _also_ an "expression":
 
-(+ 1 2) ; an expression
+(+ 1 2)
 
-(+ (+ 1 2) (+ 1 2)) ; an expression of nested expressions
+(+ (+ 1 2) (+ 1 2))
 
 (+ (+ (+ 1 2) (+ 1 2))
-   (+ (+ 1 2) (+ 1 2))) ; an even more nested expression
+   (+ (+ 1 2) (+ 1 2)))
 
 
 ;; In fact, ALL Clojure code is just "expressions"
 ;; - And, all Clojure expressions evaluate to a value.
-;;
-;; - All literals evaluate to themselves.
-;;   (Hence "literal": it is what it is. :-D)
-;;
-;; - All collection literals also evaluate to themselves.
-;;   (A literal collection is what it is, too.)
-;;
-;; - All functions are values.
-;;   (More on this a little later)
-;;
-;; - All expressions, however deeply nested, finally evaluate to a value
-;;   (Either a literal, or a collection, or a function).
 
 
-
-;; Clojure expression syntax rules:
+;; DEMO: Clojure expression syntax rules:
 ;;
 ;; - Literals:
-;;   - Just write them down
-;;
+
 ;; - Collection Literals:
-;;   - Just write them down too, but also
-;;   - make sure opening brackets are always matched by closing brackets
-;;     [1 2 3 4]   is a well-formed vector representation
-;;     [1 2 3 4    what's this? Nobody knows, and Clojure will complain.
-;;
+
 ;; - "Code expressions":
-;;   - Make sure the round parentheses close over the intended/required
-;;     sub-expressions
-;;     (+ 1 2)     is a well-formed expression that will be evaluated
-;;     (+ 1 2      what's this? Nobody knows, and Clojure will complain.
 
 
 ;; Clojure "code expressions" are called "s-expressions", because:
@@ -103,83 +58,22 @@ reduce                                  ; transform a collection
 
 
 
-;; Clojure Code Evaluation Rules:
-;;
-;; - To instruct Clojure to evaluate a list of expressions,
-;;   enclose the expressions in round parentheses.
-;;   - Recall: (+ 1 2)
-;;
-;; - The very first expression after an opening paren MUST be
-;;   a function.
-;;   - So: (1 2) will fail, because 1 is not a function
-;;
-;; - All expressions or sub-expressions that follow the first expression
-;;   will first be fully evaluated into values, and then passed to
-;;   the first expression as arguments.
-;;   - Recall: (+ (+ (+ 1 2) (+ 1 2))
-;;                (+ (+ 1 2) (+ 1 2)))
-;;
-;; - To prevent evaluation, explicitly mark an expression as a list
-;;   '(1 2) put a single quote in front of an expression to tell Clojure
-;;   you don't want it to evaluate that expression.
-;;
-;; - To comment out in-line comment text, or even an expression,
-;;   place one or more semi-colons before the text/expression.
-;;
-;; - `#_` is a clean way to comment out multi-line s-expressions
-;;   Compare this:
-#_(+ 1 2
-     3 4
-     5 6)
-;;   With this:
-;; (+ 1 2
-;;    3 4
-;;    5 6)
+;; DEMO: Clojure Code Evaluation Rules
 
 
 
-;; Why is Clojure a "List Processing" language?
+;; DEMO: Why is Clojure a "List Processing" language?
 
-'(+ 1 2) ; Recall: this is a Clojure list, that Clojure evaluates
-         ; as literal data.
+'(+ 1 2) ; list of expressions
 
-(+ 1 2) ; if we remove the single quote, Clojure treats the same list
-        ; as an executable list, and tries to evaluate it as code.
+(+ 1 2)  ; executable s-expression
 
 
-;; More generally, Clojure code, like other lisps, is written
-;; in terms of its own data structures. For example:
-;;
 ;; Here is a function definition.
+
 (defn hie
   [person message]
   (str "Hie, " person " : " message))
 
-;;What does it look like?
 
-;;[1] [2]   [3]              [4]
-(defn hie [person message] (str "Hie, " person " : " message)) ; [5]
-;; Where:
-;; - [1] `defn` is a Clojure built-in
-;;   - Notice, it's at the 1st position, and
-;;   - 2-4 are all arguments to defn
-;; Further:
-;; - [2] is a Clojure symbol, `hello`, which will name the function
-;; - [3] is a Clojure vector of two named arguments
-;; - [4] is a Clojure s-expression, and is treated as the body of
-;;       the function definition
-;; - [5] the whole thing itself is a Clojure s-expression!
-
-
-
-;; RECAP:
-;;
-;; - All Clojure code is a bunch of "expressions"
-;;   (literals, collections, s-expressions)
-;;
-;; - All Clojure expressions evaluate to a return value
-;;
-;; - All Clojure code is written in terms of its own data structures
-;;
-;; - All opening braces or parentheses must be matched by closing
-;;   braces or parentheses, to create legal Clojure expressions.
+;; What does it look like?

--- a/src/clojure_by_example/ex00_introduction.clj
+++ b/src/clojure_by_example/ex00_introduction.clj
@@ -140,17 +140,15 @@ reduce                                  ; transform a collection
 
 ;; Why is Clojure a "List Processing" language?
 
-(+ 1 2) ; is a Clojure expression, that Clojure will evaluate as code
+'(+ 1 2) ; Recall: this is a Clojure list, that Clojure evaluates
+         ; as literal data.
 
-'(+ 1 2) ; is a Clojure list, that Clojure will evaluate as literal data
-
-(eval '(+ 1 2)) ; eval is a special function that will take a literal
-                ; expression and attempt to evaluate it as if it's code
-                ; (Ignore details of eval, just know it does this.)
+(+ 1 2) ; if we remove the single quote, Clojure treats the same list
+        ; as an executable list, and tries to evaluate it as code.
 
 
-;; Clojure code, like other lisps, is written in terms of its
-;; own data structures.
+;; More generally, Clojure code, like other lisps, is written
+;; in terms of its own data structures. For example:
 ;;
 ;; Here is a function definition.
 (defn hie

--- a/src/clojure_by_example/ex01_small_beginnings.clj
+++ b/src/clojure_by_example/ex01_small_beginnings.clj
@@ -1,14 +1,5 @@
 (ns clojure-by-example.ex01-small-beginnings)
 
-
-;; Ex01: LESSON GOAL:
-;;
-;; - Show a way to model things with pure data, in the form of hash-maps
-;; - Show how to query hash-maps
-;; - Introduce the idea of a function
-;; - Use the above to show how we can "do more with less"
-
-
 ;; Our Earth
 
 ;; "name"   "Earth"
@@ -23,14 +14,9 @@
 ;;                              "traces" 0.14
 
 
-;; Looks like a collection of name-value pairs. To some, it will
-;; look like JSON.
-;;
-;; This intuition is correct. We can describe the Earth by its
-;; properties, written as name-value pairs or "key"-value pairs.
 
-;; If we put curly braces in the right places, it becomes a
-;; Clojure "hash-map":
+
+;; Our Earth as a Clojure "hash-map":
 
 {"name" "Earth"
  "mass" 1
@@ -44,13 +30,8 @@
                                "traces" 0.14}}}
 
 
-;; Let's query the Earth.
 
-;; But first, let's create a global reference to our hash-map,
-;; for convenience.
-
-;; Let's call it `earth`.
-
+;; Globally reference the hash-map, and call it `earth`:
 
 (def earth
   {"name" "Earth"
@@ -62,37 +43,21 @@
                  "CO2"           0.40
                  "water-vapour"  0.10
                  "other-gases"   {"argon"  0.33
-                                  "traces" 0.14}}}) ; <- evaluate this
-;; To evaluate the above `def`:
-;; - Place the cursor just after the closing paren `)`, and
-;; - evaluate it using your editor's evaluate feature
-;;   (in LightTable, hit ctrl+Enter on Win/Linux, and cmd+Enter on Mac)
-
-;; Evaluation will attach (or 'bind') the hash-map to the symbol
-;; we have called `earth`.
+                                  "traces" 0.14}}})
 
 
 ;; _Now_ let's query the 'earth' global...
 
-
 ;; Top-level access:
 
-;; Wait!
-;;
-;; What do you _expect_ 'get' to do, in the expression below?
-;;
-;; Try to predict, before you evaluate.
-
-(get earth "name") ; <- place cursor after closing paren and evaluate.
-
-
+(get earth "name")
 
 ;; EXERCISE:
 ;;
 ;; How to get number of moons?
 ;; - Uncomment, and fix the expression below:
 
-;; (get earth 'FIX)
+#_(get earth 'FIX)
 
 
 ;; EXERCISE:
@@ -100,12 +65,7 @@
 ;; What does the atmosphere contain?
 ;; - Type your expression below:
 
-
-;; Lesson:
-;; - Given a hash-map and a "key", `get` returns the value
-;;   associated with the key.
-;; - A value can be a string, or a number, or even another hash-map.
-
+#_('F 'I 'X)
 
 
 ;; Nested access:
@@ -113,10 +73,8 @@
 ;; EXERCISE:
 ;;
 ;; Now, how to find what the other gases are, in the atmosphere?
-;; - Hint: Mentally replace FIX with the value of "atmosphere".
-;; - Now ask yourself, what expression will return that value?
 
-;; (get 'FIX "other-gases")
+#_(get ('FIX 'FIX 'FIX) "other-gases")
 
 
 ;; EXERCISE:
@@ -127,28 +85,14 @@
 
 
 
-;; Lesson:
-;; - You can put expressions inside expressions and evaluate the
-;;   whole thing as one expression.
-
-;; Note:
-;; - We may choose to indent a deeply nested expression, for clarity.
-;;   (Ask your instructor to demonstrate.)
-
-
-
-;; A Simple "Function"
-
-;; Let's make our own function to access any "third" level value...
+;; A Simple "Function", to access any "third" level value...
 
 (defn get-level-3 ; function name
   [planet level1-key level2-key level3-key] ; arguments list
   ;; function "body":
   (get (get (get planet level1-key)
             level2-key)
-       level3-key)) ; What does the function's "body" look like?
-
-
+       level3-key)) ; Compare with the previous expression.
 
 ;; Now we can...
 (get-level-3 earth "atmosphere" "other-gases" "argon")
@@ -158,26 +102,14 @@
 
 ;; Keywords as Keys of Hash-maps
 
-;; Hash-maps so widely-used, and can so conveniently represent things,
-;; that Clojure provides a far more convenient way to define hash-maps
-;; and query them.
-
-;; Instead of plain old strings as keys, we can use
-;; Clojure "keywords" as keys.
-
 "moons" ; a string
 
 :moons  ; a keyword
 
 
-;; Like strings and numbers, keywords directly "represent" themselves.
-;; (A keyword is a fundamental data type.)
-;; _Unlike_ strings, keywords are designed to do special things.
 
-;; To find out, we must first define an alternative hash-map,
-;; - that represents the same data about the Earth,
-;; - but with keywords as keys, instead of strings
-;; - to let us super-easily query the hash-map, using just keywords
+;; Defining an alternative hash-map, with keywords as keys:
+
 (def earth-alt {:name "Earth"
                 :mass 1
                 :radius 1
@@ -204,7 +136,7 @@
 ;;
 ;; How to find the atmosphere? Uncomment,fix, and evaluate:
 
-;; ('FIX earth-alt)
+#_('FIX earth-alt)
 
 
 ;; EXERCISE:
@@ -212,7 +144,7 @@
 ;; What are the other gases, in the atmosphere?
 ;; Hint: Remember, we can nest expressions inside expressions.
 
-;; ('FIX 'FIX)
+#_('FIX 'FIX)
 
 
 ;; EXERCISE:
@@ -220,14 +152,12 @@
 ;; How much argon is present in the atmosphere?
 ;; Hint: once again, more nested expressions.
 
-;; ('FIX 'FIX)
+#_('FIX 'FIX)
 
 
-;; Clojure provides `get-in`, because nested access is so common.
-;; - `get-in` is the cousin of `get` (and the granddaddy of our
-;;    get-level-3 function!)
 
-;; Try evaluating each one of these...
+;; Clojure provides `get-in` for nested access
+
 (get-in earth-alt [:atmosphere])
 (get-in earth-alt [:atmosphere :other-gases])
 (get-in earth-alt [:atmosphere :other-gases :argon])
@@ -241,45 +171,30 @@
 
 ;; EXERCISE:
 ;;
-;; We saw `get-in` work for keywords. Does it work for strings too?
-;; Uncomment, fix, and evaluate:
+;; Does `get-in` work for strings too?
 
-;; (get-in earth 'FIX)
-
-
-;; Did that work? Why or why not?
-
-
-;; EXERCISE:
-;;
-;; Use get-in to query other gases from the `earth` hash-map.
-;; Type your expression below and evaluate it:
+#_(get-in earth 'FIX)
 
 
 
 ;; EXERCISE:
 ;;
-;; Use get-in to query argon from `earth`'s atmosphere
-;; Type your expression below and evaluate it:
+;; Use `get-in` to query other gases from the `earth` hash-map.
 
 
 
-;; Lesson:
-;; - Given a hash-map and a path "key", `get` returns the value
-;;   associated with the key.
+;; EXERCISE:
+;;
+;; Use `get-in` to query argon from `earth`'s atmosphere
 
 
 
-;; Clojure "Vectors":
 
-;; The square bracketed things we used with `get-in` are in fact a
-;; Clojure datastructure. (Other languages may call these "Arrays".)
+;; Clojure "Vectors" (indexed collections, like Arrays):
+
 ["atmosphere"] ; is a vector of one string
+
 [:atmosphere :other-gases]  ; is a vector of two keywords
-
-
-;; These are `indexed` collections, i.e. we can query a value in
-;; a Vector, if we know what "index" position it occupies in the vector.
 
 
 ;; EXERCISE:
@@ -287,7 +202,6 @@
 ;; What will this return?
 
 (get [:foo :bar :baz] 0)
-;; Note: We count position starting at `0`, not `1`, in Clojure
 
 
 ;; EXERCISE:
@@ -297,31 +211,23 @@
 (get-in [:foo [:bar :baz]] [1 1])
 
 
-;; But we are actually just trying to find the "nth" item,
-;; and Clojure gives us...
+;; Same as:
+
 (nth [:foo :bar :baz] 0)
 
 (nth (nth [:foo [:bar :baz]] 1)
      1)
 
-;; Lesson:
-;; - `get` and `get-in` are general enough to query Vectors too,
-;;   using index number.
-;; - but we'd rather just look up the `nth` item in Vectors
 
 
-;; Basic Data Modeling:
-
-;; We rarely use vectors to model objects like the Earth.
-;; A hash-map is almost always the right way to model an object.
-;; the thing we need to query.
+;; DEMO: Basic Data Modeling:
 
 
 ;; What if we model the earth as a vector, instead of a hash-map?
 (def earth-as-a-vector
   "Docstring: This vector represents Earth this way:
-  [Name, Radius, Mass, Moons]"
-  ["Earth" 1 1 1])
+  [Name     Radius  Mass  Moons]"
+  ["Earth"  1       1     1])
 
 
 ;; Now, how do we query Earth?
@@ -332,39 +238,25 @@
 
 (get-earth-name)
 
+
 (defn get-earth-radius []
   (get earth-as-a-vector 1))
 
 (get-earth-radius)
+
 
 (defn get-earth-moons []
   (get earth-as-a-vector 2)) ; Uh, was it 2 or 3?
 
 (get-earth-moons) ; did this return Mass, or Moons?
 
-(:moons earth-alt) ; compare: how obviously we can query :moons in earth-alt
+
+;; Compare with:
+(:moons earth-alt)
 
 
-;; Further, our custom "getter" functions for Earth's properties,
-;; are useless for other planets we may wish to define.
+;; What lessons do we glean from the above exercises?
 
-
-;; Lesson: Doing More With Less:
-
-;; Clojure programmers rely on the power, and general-purpose
-;; flexibility of hash-maps, as well as general-purpose functions,
-;; to avoid getting stuck in such situations.
-
-;; While nobody stops us from doing so, using vectors to model an object
-;; (like the Earth) is clearly awkward.
-;; - We must maintain label/name information about values separately
-;;   (perhaps in the docstring)
-;; - Our custom `get-xyz` functions are also far too "specialized",
-;;   i.e. we can only sensibly use them to query _only_ the earth.
-;; - And it opens us up to a whole host of errors:
-;;   - we can easily lose track of what value represents what property
-;;   - what if someone decides to add the number of man-made satellites
-;;     between mass and moon?
 
 
 ;; Lesson-end Exercises:
@@ -375,17 +267,17 @@
 ;; Use the information below.
 ;;
 #_(;; FIXME
-   "Mercury"    ; has...
-   moons 0
-   mass 0.0553  ; recall we assume Earth mass is 1
-   radius 0.383 ; recall we assume Earth radius is 1
-   atmosphere   ; % of total volume
-      oxygen      42.0
-      sodium      29.0
-      hydrogen    22.0
-      helium      6.0
-      potassium   0.5
-      other-gases 0.5)
+   :name "Mercury"    ; has...
+   :moons 0
+   :mass 0.0553  ; recall we assume Earth mass is 1
+   :radius 0.383 ; recall we assume Earth radius is 1
+   :atmosphere   ; % of total volume
+      :oxygen      42.0
+      :sodium      29.0
+      :hydrogen    22.0
+      :helium      6.0
+      :potassium   0.5
+      :other-gases 0.5)
 
 
 
@@ -393,9 +285,12 @@
 ;;
 ;; Query the planet `mercury` in 3 ways:
 ;; - with nested `get`
+
+
 ;; - with get-in
+
+
 ;; - with keywords
-;; Type your solutions below:
 
 
 
@@ -403,23 +298,7 @@
 ;;
 ;; Write a custom function to do a two-level deep query on `mercury`.
 ;; - It should be able to query earth, and earth-alt as well.
-;; Type your solution below:
 
-
-
-
-
-;; RECAP:
-;;
-;; - hash-maps let us conveniently represent objects we wish to
-;;   model and query
-;; - We can query hash-maps variously with keywords, `get`, and `get-in`
-;; - If we use keywords as keys in hash-maps, querying is dead-simple
-;; - We can define our own functions with `defn`, using this syntax:
-;;
-;;   (defn function-name
-;;         [arg1 arg2 arg3 ... argN]
-;;         (body of the function))
-;;
-;; - Using general-purpose data structures, and writing general-purpose
-;;   functions lets us do more with less
+#_(defn get-level-2
+    ['FIX ...]
+    'FIX)

--- a/src/clojure_by_example/ex02_small_functions.clj
+++ b/src/clojure_by_example/ex02_small_functions.clj
@@ -1,16 +1,5 @@
 (ns clojure-by-example.ex02-small-functions)
 
-;; Ex02: LESSON GOALS
-;;
-;; - Learn to define simple functions, and use them
-;; - Learn a little bit about how functions behave
-;; - Learn about a few useful built-in Clojure functions
-;;   (We will use these in later exercises.)
-;; - Stitch up ideas in this section with a small insight
-;;   into how we can use functions on vectors and hash-maps.
-;;   (Set up your intuition, for later exercises.)
-
-
 ;; First, some simple functions:
 
 
@@ -22,15 +11,11 @@
 ;;   (body of the function))
 
 
-;; `defn` stands for:
-;; - "DEfine a FuNction,
-;; - _and_ give it a globally-referenced name"
-
-
 (defn same
   "Simply return the input unchanged."
   [x]
   x)
+
 
 ;; EXERCISE
 ;;
@@ -69,24 +54,11 @@
 ((fn [x] x) [1 2 3 4 5])
 
 
-;; We will make good use of such "anonymous" functions soon.
-;; Just understand they are just like 'regular' functions, except
-;; they do not have a globally-referenced name (hence "anonymous").
-
-
-;; Reminder: Do More With Less!
-;; - Observe that `same` as well as `(fn [x] x)` appear to be capable
-;;   of accepting _any_ kind of value and returning it.
-;; - This function definition is very general-purpose indeed.
-;; - We will frequently use this "general-purpose" idea.
-
 
 ;; Some "built-in" functions
 
-;; Clojure has a function called `fn?`, that returns true if we
-;; pass it something that is a function, and false otherwise.
+;; - `fn?` is a function that returns true if we pass it a function
 
-;; None of these are functions. So, return `false`.
 
 (fn? 42)
 
@@ -105,15 +77,7 @@
 (fn? fn?)
 
 
-;; Wait a minute...!!!
-;;
-;; We just passed functions as arguments to `fn?`, and it worked!
-;;
-;; Is `fn?` special, or can we pass any function to any function?
-
-;; Well we know `fn?` is a function...
-;; - Suppose we pass `fn?` to `same`, do we get back `fn?` unchanged?
-
+;; Suppose we pass `fn?` to `same`?
 (= fn?
    (same fn?))
 
@@ -128,21 +92,6 @@
 (= 'FIX
    (same same))
 
-
-;; Lesson: Functions also behave like "values":
-;;
-;; - `42` is a value. `"moons"` is a value. `:moons` is a value.
-;;   - Values represent themselves directly
-;;   - Values are unique in the whole universe (42 is NOT "forty two")
-;;   - Values never change. They are constant forever and ever.
-;;
-;; - All Clojure function also are "values", including user-defined
-;;   functions (like `same`). And, just like the other values...
-;;   - We can pass functions as arguments to other functions,
-;;     without any special syntax or declarations.
-;;   - Functions can _return_ functions as results.
-;;   - We can compare any two functions and tell if they are
-;;     exactly the same thing.
 
 
 ;; Some other "built-in" Clojure functions
@@ -162,44 +111,35 @@
    (same :moon))
 
 
-;; `map` a function over a collection...
+
+;; `map`
+;; - a function over a collection...
+
 (map inc [1 2 3 4 5 6])
 
 ;; Such that...
-(comment ( 1 2 3 4 5 6))  ; each item of input
-;;         | | | | | |   ; is incremented by `inc` to give a result where
-(comment ( 2 3 4 5 6 7))  ; each output item "maps" back to an input item
-
-;; In general, we can use `map` to express one-to-one "mappings"
-;; of input and output, by way of a function.
-
+'( 1 2 3 4 5 6)  ; each item of input
+;; | | | | | |   ; is incremented by `inc` to give a result where
+'( 2 3 4 5 6 7)  ; each output item "maps" back to an input item
 
 
 ;; EXERCISE:
 ;;
 ;; What should this return?
-;; First predict the answer, then evaluate to confirm.
 (map even? [1 2 3 4 5 6])
-;; Hint: mentally apply the `even?` function to each item, one by one,
-;; and build up a collection of results of each function application.
+
 
 
 ;; How about this?
-
 (map odd? [1 2 3 4 5 6])
 
 
 ;; And this?
-
 (map identity [1 2 3 4 5 6]) ; Recall: `identity` is just like `same`
 
 
 ;; And this?
-
 (map (fn [x] x) [1 2 3 4 5 6])
-
-;; Our anonymous "identity" function is a drop-in replacement
-;; for `identity`, as well as `same`.
 
 
 
@@ -216,7 +156,7 @@
 [{:name "Mercury" :moons 0}
  {:name "Venus"   :moons 0}
  {:name "Earth"   :moons 1}
- {:name "Mars"    :moons 2}] ; (Yes we can do this. More on this later!)
+ {:name "Mars"    :moons 2}]
 
 
 ;; Let's name our collection of planets as, um... `planets`
@@ -227,7 +167,7 @@
               {:name "Mars"    :moons 2}])
 
 
-;; Recall that we can query a map, like this:
+;; Recall that we can query a hash-map, like this:
 
 (:name {:name "Mercury" :moons 0})
 
@@ -238,12 +178,8 @@
 ;;
 ;; What if we pass a keyword instead of a real function, to `map`?
 ;; - What should the following map expression return?
-;; - Predict the answer, and then evaluate to confirm.
 
 (map :name planets)
-
-;; (map :name over `planets`, which is vector of planet hash-maps)
-
 
 
 ;; Stitching it all together...
@@ -267,12 +203,10 @@
 
 ;; EXERCISE
 ;;
-;; Instead of querying each map, why not query all of them at one go?
+;; Instead of querying each hash-map for moons, why not
+;; query all of them at one go?
 
 #_(map 'FIX 'FIX)
-
-
-;; Also, as we now know, we can use anonymous functions creatively...
 
 
 ;; EXERCISE
@@ -292,24 +226,3 @@
      ('FIX 'FIX 'FIX)  ; use anonymous function
 
      [false false true true])
-
-
-
-;; RECAP:
-;; - Functions are easy to define
-;; - Functions can _accept_ functions as arguments
-;; - Functions can _return_ functions as arguments
-;; - Clojure has nifty "built-in" functions
-;;   - e.g. the function `map` lets us express a mapping of an
-;;     input collection to an output collection, by way of a function.
-
-
-;; DO MORE WITH LESS:
-;; - Even the most simple functions can be general-purpose
-;; - Clojure keywords behave like functions of hash-maps
-;; - Since keywords can query hash-maps, we can completely avoid writing
-;;   custom "getter" functions to query values in our hash-maps.
-;; - We can put hash-maps in vectors, to make vectors of hash-maps.
-;; - Since `map` accepts keywords in place of functions, we can
-;;   combine the above tiny set of ideas, to query many planetary hash-
-;;   maps at one go.

--- a/src/clojure_by_example/ex04_control_flow.clj
+++ b/src/clojure_by_example/ex04_control_flow.clj
@@ -312,7 +312,6 @@
 ;; - can be used as predicates (and often are used this way)
 
 (= #{:a :b :c}  ; A hash-set of three things, :a, :b, and :c.
-
    (hash-set :a :b :b :c :a :c :c :c))
 
 
@@ -335,8 +334,11 @@
 
 
 (filter (comp colonize-it? :name)
-        [{:name "Mercury"} {:name "Venus"} {:name "Earth"}
-         {:name "Mars"} {:name "Jupiter"}])
+        [{:name "Mercury"}
+         {:name "Venus"}
+         {:name "Earth"}
+         {:name "Mars"}
+         {:name "Jupiter"}])
 
 
 
@@ -381,7 +383,7 @@
 ;; - Let's say :chlorine, :sulphur-dioxide, :carbon-monoxide are poisons
 
 
-;; Quick-n-dirty test
+;; Is the gas poisonous?
 #_(poison-gases :oxygen)
 #_(poison-gases :chlorine)
 
@@ -413,8 +415,8 @@
 ;;
 ;; Having no atmosphere is a bad thing, you know.
 ;;
-;; Write a "predicate" function that returns true (or truthy)
-;; if a planet has no atmosphere. It should return false/falsey
+;; Write a "predicate" function that returns truthy
+;; if a planet has no atmosphere. It should return falsey
 ;; if the planet _has_ an atmosphere.
 ;;
 ;; Call it `no-atmosphere?`
@@ -648,7 +650,7 @@
 ;;   increasingly sophisticated tasks.
 ;;
 ;; - We tend to think in terms of sequences, and sequence operations.
-;;   (As opposed to looping opertions on items of sequences.)
+;;   (As opposed to looping operations on items of sequences.)
 ;;
 ;; - We strongly prefer to model real-world objects as pure data,
 ;;   then and use many small functions to progressively transform our

--- a/src/clojure_by_example/ex06_full_functional_firepower.clj
+++ b/src/clojure_by_example/ex06_full_functional_firepower.clj
@@ -175,7 +175,7 @@
 ;; --------------------- Purely Functional Program begins --------------
 
 
-(defn sensor-data->planet
+(defn add-sensor-data
   "Given a sensor key, a planetary hash-map, and a tuple having
   sensor data for a planet, inject the sensor data under the
   planet name found in the planetary hash-map."
@@ -188,18 +188,18 @@
 ;; `assoc-in` (nested map) is the partner of `get-in` (from nested map).
 
 
-(defn moons->planets
+(defn add-moon-data
   "Inject moons sensor data, into planets sensor data."
   [moons planets]
-  (reduce (partial sensor-data->planet :moons)
+  (reduce (partial add-sensor-data :moons)
           planets
           moons))
 
 
-(defn atmosphere->planets
+(defn add-atmosphere-data
   "Inject atmosphere sensor data, into planets sensor data."
   [atmosphere planets]
-  (reduce (partial sensor-data->planet :atmosphere)
+  (reduce (partial add-sensor-data :atmosphere)
           planets
           atmosphere))
 
@@ -218,14 +218,14 @@
        planets))
 
 
-(defn denormalized-planetary-data
+(defn denormalised-planetary-data
   "Given all sensor data, produce a collection of denormalized
   planetary data."
   [{:keys [planets atmosphere moons]
     :as all-sensor-data}]
   ((comp denormalise-planetary-data
-         (partial atmosphere->planets atmosphere)
-         (partial moons->planets moons))
+         (partial add-atmosphere-data atmosphere)
+         (partial add-moon-data moons))
    planets))
 
 
@@ -233,7 +233,7 @@
 
 
 ;; First try this, to check packaged data...
-#_(denormalized-planetary-data
+#_(denormalised-planetary-data
    (gather-all-sensor-data! sensor-data-dir
                             sensor-data-files))
 
@@ -252,7 +252,7 @@
   (write-out-json-file
    data-dir
    dest-data-file
-   (denormalized-planetary-data
+   (denormalised-planetary-data
     (gather-all-sensor-data! data-dir source-data-files))))
 
 
@@ -273,7 +273,7 @@
 ;; The Planetary Data Scientists reveal their nefarious intentions:
 
 #_(clojure-by-example.ex04-control-flow/colonize-habitable-planets!
-   (denormalized-planetary-data
+   (denormalised-planetary-data
     (gather-all-sensor-data! sensor-data-dir
                              sensor-data-files)))
 ;; Note:


### PR DESCRIPTION
Removed comments from ex00..02, in order to prep the branch for live class. 

Have a look-see and tell me if this kind of elision is fine.